### PR TITLE
Make Chef 13 compatible

### DIFF
--- a/providers/config.rb
+++ b/providers/config.rb
@@ -89,7 +89,7 @@ action :delete do
 end
 
 def load_current_resource
-  @current_resource = Chef::Resource::GunicornConfig.new(@new_resource.name)
+  @current_resource = Chef::Resource.resource_for_node(:gunicorn_config, node).new(@new_resource.name)
   @current_resource.path(@new_resource.path)
   @current_resource
 end

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -55,7 +55,7 @@ attribute :proc_name, kind_of: String, default: nil
 
 attribute :server_hooks, kind_of: Hash, default: nil, \
                          callbacks: {
-                           'should contain a valid gunicorn server hook name' => ->(hooks) { Chef::Resource::GunicornConfig.validate_server_hook_hash_keys(hooks) },
+                           'should contain a valid gunicorn server hook name' => ->(hooks) { Chef::Resource.resource_for_node(:gunicorn_config, node).validate_server_hook_hash_keys(hooks) },
                          }
 
 attribute :raw_env, kind_of: Array, default: nil


### PR DESCRIPTION
The old method of accessing the class for the custom resource doesn't
work in Chef 13 anymore. Make the minimal fix, taken from
sous-chefs/redisio#350.

Signed-off-by: Matthias Rampke <mr@soundcloud.com>